### PR TITLE
add fraction formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ See https://github.com/samg/timetrap/issues#issue/13 for more details.
         ---------------------------------------------------------
         Total                                    6:00:00
 
+### Fraction
+
+The *fraction* formatter is also like the default *text* formatter. In addition
+to the information that is normally shown, it show the duration of the entry as
+a fraction of an hour. This is useful for entry into some time accounting
+systems.
+
+    $ t d -ffraction
+    Timesheet: mysheet
+        Day                Start   End     Duration        Notes
+        Wed Apr 23, 2014   10:12 - 10:15   0:02:23   0.04  entry
+                           14:29 - 14:57   0:28:05   0.47
+                           14:57 - 15:14   0:17:05   0.28  note
+                           15:14 - 15:51   0:36:57   0.62
+                           15:51 - 15:53   0:01:58   0.03
+                                           1:26:28   1.44
+        ---------------------------------------------------------
+        Total                              5:12:47   5.21
+
 ### LaTeX Invoice
 The *invoice* formatter generates LaTeX output that will create a nice looking
 invoice.  In order to generate the resulting LaTeX output, you must have

--- a/formatters/fraction.rb
+++ b/formatters/fraction.rb
@@ -1,0 +1,69 @@
+module Timetrap
+  module Formatters
+    class Fraction
+      attr_accessor :output
+      include Timetrap::Helpers
+
+      def format_time t
+        return '' unless t.respond_to?(:strftime)
+        return t.strftime('%H:%M')
+      end
+
+      def initialize entries
+        self.output = ''
+        sheets = entries.inject({}) do |h, e|
+          h[e.sheet] ||= []
+          h[e.sheet] << e
+          h
+        end
+        (sheet_names = sheets.keys.sort).each do |sheet|
+          self.output <<  "Timesheet: #{sheet}\n"
+          id_heading = Timetrap::CLI.args['-v'] ? 'Id' : '  '
+          self.output <<  "#{id_heading}  Day                Start   End     Duration        Notes\n"
+          last_start = nil
+          from_current_day = []
+          sheets[sheet].each_with_index do |e, i|
+            from_current_day << e
+            self.output <<  "%-4s%16s%8s -%6s%10s% 7.2f  %s\n" % [
+              (Timetrap::CLI.args['-v'] ? e.id : ''),
+              format_date_if_new(e.start, last_start),
+              format_time(e.start),
+              format_time(e.end),
+              format_duration(e.duration),
+              e.duration / 3600.0,
+              e.note
+            ]
+
+            nxt = sheets[sheet].to_a[i+1]
+            if nxt == nil or !same_day?(e.start, nxt.start)
+              self.output <<  "%46s% 7.2f\n" % [
+                format_total(from_current_day),
+                from_current_day.inject(0) {|sum, e| sum + (e.duration/3600.0)}
+              ]
+              from_current_day = []
+            else
+            end
+            last_start = e.start
+          end
+          self.output <<  <<-OUT
+    ---------------------------------------------------------
+          OUT
+          self.output <<  "    Total%37s% 7.2f\n" % [
+            format_total(sheets[sheet]),
+            sheets[sheet].inject(0) {|s, e| s + (e.duration / 3600.0)}
+          ]
+          self.output <<  "\n" unless sheet == sheet_names.last
+        end
+        if sheets.size > 1
+          self.output <<  <<-OUT
+-------------------------------------------------------------
+          OUT
+          self.output <<  "Grand Total%35s% 7.2f\n" % [
+            format_total(sheets.values.flatten),
+            sheets.values.flatten.inject(0) {|s, e| s + (e.duration / 3600.0)}
+          ]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This formatter also shows the duration as a fraction of an hour (30 minutes = 0.5), for easy entry into some time accounting and task management systems.
