### PR TITLE
New formatter which group spent time by notes

### DIFF
--- a/formatters/sum_notes.rb
+++ b/formatters/sum_notes.rb
@@ -1,0 +1,9 @@
+class Timetrap::Formatters::SumNotes
+  def initialize(entries)
+    @entries = entries
+  end
+
+  def output
+    @entries.map{|entry| entry[:note]}.join("\n")
+  end
+end

--- a/formatters/sum_notes.rb
+++ b/formatters/sum_notes.rb
@@ -1,3 +1,19 @@
+# text formatter for sum of spent time grouped by note.
+#
+# $ t d other -f sum_notes
+#
+# Timesheet: other
+#   Duration   Notes
+#   0:46:03    bank
+#   0:27:37    blogs
+#   0:52:36    coffee
+#   0:48:24    lunch
+#   0:18:02    tea
+#
+# Alexander Sapozhnikov
+# http://shoorick.ru
+# shoorick@cpan.org
+
 module Timetrap
   module Formatters
     class SumNotes

--- a/formatters/sum_notes.rb
+++ b/formatters/sum_notes.rb
@@ -11,14 +11,21 @@ module Timetrap
           h[e.sheet] << e
           h
         end
-        
+
         sheets.keys.sort.each do |sheet|
           self.output <<  "Timesheet: #{sheet}\n"
-          sheets[sheet].each_with_index do |e, i|
-            #from_current_day << e
+          self.output << "   Duration   Notes\n"
+
+          durations = {}
+          sheets[sheet].each do |e|
+            durations[e.note] ||= 0
+            durations[e.note]  += e.duration
+          end
+
+          durations.keys.sort.each do |d|
             self.output <<  "%10s    %s\n" % [
-              format_duration(e.duration),
-              e.note
+              format_duration(durations[d]),
+              d
             ]
           end
         end

--- a/formatters/sum_notes.rb
+++ b/formatters/sum_notes.rb
@@ -13,7 +13,7 @@ module Timetrap
         end
 
         sheets.keys.sort.each do |sheet|
-          self.output <<  "Timesheet: #{sheet}\n"
+          self.output <<  "\nTimesheet: #{sheet}\n"
           self.output << "   Duration   Notes\n"
 
           durations = {}

--- a/formatters/sum_notes.rb
+++ b/formatters/sum_notes.rb
@@ -1,9 +1,28 @@
-class Timetrap::Formatters::SumNotes
-  def initialize(entries)
-    @entries = entries
-  end
+module Timetrap
+  module Formatters
+    class SumNotes
+      attr_accessor :output
+      include Timetrap::Helpers
 
-  def output
-    @entries.map{|entry| entry[:note]}.join("\n")
+      def initialize(entries)
+        self.output = ''
+        sheets = entries.inject({}) do |h, e|
+          h[e.sheet] ||= []
+          h[e.sheet] << e
+          h
+        end
+        
+        sheets.keys.sort.each do |sheet|
+          self.output <<  "Timesheet: #{sheet}\n"
+          sheets[sheet].each_with_index do |e, i|
+            #from_current_day << e
+            self.output <<  "%10s    %s\n" % [
+              format_duration(e.duration),
+              e.note
+            ]
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes I need to calculate sum of spent time not only by sheets but by notes too. There is a formatter which collect these sums.

```
$ t d --start '5 days ago' other -f sum_notes

Timesheet: other
   Duration   Notes
   0:28:43    coffee
   0:32:12    lunch
```

Compare it with usual report:

```
$ t d --start '5 days ago' other
Timesheet: other
    Day                Start      End        Duration   Notes
    Wed Feb 11, 2015   12:55:58 - 13:11:01   0:15:03    lunch
                       13:11:05 - 13:39:48   0:28:43    coffee
                                             0:43:46
    Mon Feb 16, 2015   12:59:27 - 13:16:36   0:17:09    lunch
                                             0:17:09
    ----------------------------------------------------------
    Total                                    1:00:55
```

I am not a ruby programmer and may be I will not extend my formatter because current version of it successfully solves my task – sum time by notes.
