### PR TITLE
add total formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ Also supports prefixes and suffixes, so to have your pay printed in dollars, set
 which will be printed after each pay amount as such: `$3.14M` if you make, say,
 3.14 million USD per hour.
 
+### total formatter
+
+This formatter simply displays the total amount of hours logged on this
+timesheet as a decimal number.
+
+```
+$ t d -ftotal
+4.709
+```
+
 ### Harvest formatter
 
 The Harvest formatter, developed separately as the [timetrap-harvest][timetrap-harvest] gem, will

--- a/formatters/total.rb
+++ b/formatters/total.rb
@@ -1,0 +1,15 @@
+class Timetrap::Formatters::Total
+  include Timetrap::Helpers
+
+  def initialize(entries)
+    @entries = entries
+  end
+
+  def output
+    total = 0.0
+    @entries.each do |entry|
+      total += entry.duration / 3600.0
+    end
+    return "%.3f\n" % total
+  end
+end


### PR DESCRIPTION
Added the `total` formatter that displays the total time as a decimal number. I use this for bash scripts, etc.

```
$ t d -ftotal
4.709
```
